### PR TITLE
Enable `best_match` method to generate base curves for unitary DX equipment

### DIFF
--- a/copper/library.py
+++ b/copper/library.py
@@ -373,32 +373,42 @@ class Library:
             if eqp.type == "chiller":
                 cap = val["ref_cap"]
                 cap_unit = val["ref_cap_unit"]
+                ref_cap = eqp.ref_cap
                 eff = val["full_eff"]
                 eff_unit = matches[name]["full_eff_unit"]
 
-                if cap is not None:
-                    # Capacity conversion
-                    if cap_unit != eqp.ref_cap_unit:
-                        c_unit = Units(cap, cap_unit)
-                        cap = c_unit.conversion(eqp.ref_cap_unit)
-                        cap_unit = eqp.ref_cap_unit
+            elif eqp.type == "UnitaryDirectExpansion":
+                cap = val["ref_net_cap"]
+                cap_unit = val["ref_cap_unit"]
+                ref_cap = eqp.ref_net_cap
+                eff = val["full_eff"]
+                eff_unit = matches[name]["full_eff_unit"]
+            else:
+                raise ValueError("Equipment type not supported.")
 
-                    # Efficiency conversion
-                    if eff_unit != eqp.full_eff_unit:
-                        c_unit = Units(eff, eff_unit)
-                        eff = c_unit.conversion(eqp.full_eff_unit)
-                        eff_unit = eqp.full_eff_unit
+            if cap is not None:
+                # Capacity conversion
+                if cap_unit != eqp.ref_cap_unit:
+                    c_unit = Units(cap, cap_unit)
+                    cap = c_unit.conversion(eqp.ref_cap_unit)
+                    cap_unit = eqp.ref_cap_unit
 
-                    # Compute difference
-                    c_diff = abs((eqp.ref_cap - cap) / eqp.ref_cap) + abs(
-                        (eqp.full_eff - eff) / eqp.full_eff
-                    )
+                # Efficiency conversion
+                if eff_unit != eqp.full_eff_unit:
+                    c_unit = Units(eff, eff_unit)
+                    eff = c_unit.conversion(eqp.full_eff_unit)
+                    eff_unit = eqp.full_eff_unit
 
-                    if c_diff < diff:
-                        # Update lowest numeric difference
-                        diff = c_diff
+                # Compute difference
+                c_diff = abs((ref_cap - cap) / ref_cap) + abs(
+                    (eqp.full_eff - eff) / eqp.full_eff
+                )
 
-                        # Update best match
-                        best_match = name
+                if c_diff < diff:
+                    # Update lowest numeric difference
+                    diff = c_diff
+
+                    # Update best match
+                    best_match = name
 
         return best_match

--- a/copper/units.py
+++ b/copper/units.py
@@ -20,6 +20,7 @@ class Units:
         """
         ton_to_kbtu = 12
         kbtu_to_kw = 3.412141633
+        # Efficiencies
         if new_unit == "kW/ton":
             if self.unit == "cop":
                 return ton_to_kbtu / (self.value * kbtu_to_kw)
@@ -64,6 +65,7 @@ class Units:
                 return self.value
             else:
                 return self.value
+        # Capacities
         elif new_unit == "ton":
             if self.unit == "kW":
                 return self.value * (kbtu_to_kw / ton_to_kbtu)
@@ -71,6 +73,10 @@ class Units:
                 return self.value * (kbtu_to_kw / (ton_to_kbtu * 1000))
             if self.unit == "ton":
                 return self.value
+            if self.unit == "kbtu/h":
+                return self.value / ton_to_kbtu
+            if self.unit == "btu/h":
+                return self.value / ton_to_kbtu / 1000
         elif new_unit == "kW":
             if self.unit == "ton":
                 return self.value / (kbtu_to_kw / ton_to_kbtu)
@@ -78,6 +84,10 @@ class Units:
                 return self.value / 1000
             if self.unit == "kW":
                 return self.value
+            if self.unit == "kbtu/h":
+                return self.value * kbtu_to_kw
+            if self.unit == "btu/h":
+                return self.value * kbtu_to_kw / 1000
         elif new_unit == "W":
             if self.unit == "ton":
                 return self.value / (kbtu_to_kw / (ton_to_kbtu * 1000))
@@ -85,6 +95,33 @@ class Units:
                 return self.value * 1000
             if self.unit == "W":
                 return self.value
+            if self.unit == "kbtu/h":
+                return self.value * kbtu_to_kw * 1000
+            if self.unit == "btu/h":
+                return self.value * kbtu_to_kw
+        elif new_unit == "kbtu/h":
+            if self.unit == "ton":
+                return self.value * ton_to_kbtu
+            if self.unit == "kW":
+                return self.value / kbtu_to_kw
+            if self.unit == "W":
+                return self.value / (kbtu_to_kw * 1000)
+            if self.unit == "kbtu/h":
+                return self.value
+            if self.unit == "btu/h":
+                return self.value / 1000
+        elif new_unit == "btu/h":
+            if self.unit == "ton":
+                return self.value * ton_to_kbtu * 1000
+            if self.unit == "kW":
+                return self.value * 1000 / kbtu_to_kw
+            if self.unit == "W":
+                return self.value * 1000 / (kbtu_to_kw * 1000)
+            if self.unit == "kbtu/h":
+                return self.value
+            if self.unit == "btu/h":
+                return self.value
+        # Temperatures
         elif new_unit == "degC":
             if self.unit == "degF":
                 return (self.value - 32) * 5 / 9

--- a/tests/test_unitarydirectexpansion.py
+++ b/tests/test_unitarydirectexpansion.py
@@ -205,6 +205,34 @@ class UnitaryDirectExpansion(TestCase):
         # Check that all curves have been generated
         assert len(set_of_curves) == 5
 
+    def test_generation_best_match(self):
+        # Define equipment characteristics
+        dx = cp.UnitaryDirectExpansion(
+            compressor_type="scroll",
+            condenser_type="air",
+            compressor_speed="constant",
+            ref_cap_unit="ton",
+            ref_gross_cap=8,
+            full_eff=11.55,
+            full_eff_unit="eer",
+            part_eff=14.8,
+            part_eff_ref_std="ahri_340/360",
+            model="simplified_bf",
+            sim_engine="energyplus",
+        )
+        # Generate the curves
+        set_of_curves = dx.generate_set_of_curves(
+            tol=0.05,
+            verbose=True,
+            method="best_match",
+            num_nearest_neighbors=5,
+            random_seed=1,
+            vars=["eir-f-t"],
+        )
+
+        # Check that all curves have been generated
+        assert len(set_of_curves) == 5
+
     def test_lib_default_props_dx(self):
         assert (
             self.lib.find_set_of_curves_from_lib()[0].eqp.__dict__["part_eff_ref_std"]


### PR DESCRIPTION
- Enable `best_match` method to generate base curves for unitary DX equipment. 
- Add unit test.
- Add docstring documentation of some existing functions